### PR TITLE
content: 1.2.50

### DIFF
--- a/app_data/sheets/template/home_screen.json
+++ b/app_data/sheets/template/home_screen.json
@@ -103,7 +103,7 @@
     },
     {
       "name": "okay_learning_steps_language",
-      "value": "@fields._app_language == \"us_en\" || @fields._app_language == \"es_es\" || @fields._app_language == \"cn_zh\" || @fields._app_language == \"fr_fr\" || @fields._app_language == \"kr_ko\" || @fields._app_language == \"tr_tr\"",
+      "value": "@fields._app_language == \"us_en\" || @fields._app_language == \"es_es\" || @fields._app_language == \"cn_zh\" || @fields._app_language == \"fr_fr\" || @fields._app_language == \"tr_tr\"",
       "_translations": {
         "value": {}
       },
@@ -113,37 +113,31 @@
       "_dynamicFields": {
         "value": [
           {
-            "fullExpression": "@fields._app_language == \"us_en\" || @fields._app_language == \"es_es\" || @fields._app_language == \"cn_zh\" || @fields._app_language == \"fr_fr\" || @fields._app_language == \"kr_ko\" || @fields._app_language == \"tr_tr\"",
+            "fullExpression": "@fields._app_language == \"us_en\" || @fields._app_language == \"es_es\" || @fields._app_language == \"cn_zh\" || @fields._app_language == \"fr_fr\" || @fields._app_language == \"tr_tr\"",
             "matchedExpression": "@fields._app_language",
             "type": "fields",
             "fieldName": "_app_language"
           },
           {
-            "fullExpression": "@fields._app_language == \"us_en\" || @fields._app_language == \"es_es\" || @fields._app_language == \"cn_zh\" || @fields._app_language == \"fr_fr\" || @fields._app_language == \"kr_ko\" || @fields._app_language == \"tr_tr\"",
+            "fullExpression": "@fields._app_language == \"us_en\" || @fields._app_language == \"es_es\" || @fields._app_language == \"cn_zh\" || @fields._app_language == \"fr_fr\" || @fields._app_language == \"tr_tr\"",
             "matchedExpression": "@fields._app_language",
             "type": "fields",
             "fieldName": "_app_language"
           },
           {
-            "fullExpression": "@fields._app_language == \"us_en\" || @fields._app_language == \"es_es\" || @fields._app_language == \"cn_zh\" || @fields._app_language == \"fr_fr\" || @fields._app_language == \"kr_ko\" || @fields._app_language == \"tr_tr\"",
+            "fullExpression": "@fields._app_language == \"us_en\" || @fields._app_language == \"es_es\" || @fields._app_language == \"cn_zh\" || @fields._app_language == \"fr_fr\" || @fields._app_language == \"tr_tr\"",
             "matchedExpression": "@fields._app_language",
             "type": "fields",
             "fieldName": "_app_language"
           },
           {
-            "fullExpression": "@fields._app_language == \"us_en\" || @fields._app_language == \"es_es\" || @fields._app_language == \"cn_zh\" || @fields._app_language == \"fr_fr\" || @fields._app_language == \"kr_ko\" || @fields._app_language == \"tr_tr\"",
+            "fullExpression": "@fields._app_language == \"us_en\" || @fields._app_language == \"es_es\" || @fields._app_language == \"cn_zh\" || @fields._app_language == \"fr_fr\" || @fields._app_language == \"tr_tr\"",
             "matchedExpression": "@fields._app_language",
             "type": "fields",
             "fieldName": "_app_language"
           },
           {
-            "fullExpression": "@fields._app_language == \"us_en\" || @fields._app_language == \"es_es\" || @fields._app_language == \"cn_zh\" || @fields._app_language == \"fr_fr\" || @fields._app_language == \"kr_ko\" || @fields._app_language == \"tr_tr\"",
-            "matchedExpression": "@fields._app_language",
-            "type": "fields",
-            "fieldName": "_app_language"
-          },
-          {
-            "fullExpression": "@fields._app_language == \"us_en\" || @fields._app_language == \"es_es\" || @fields._app_language == \"cn_zh\" || @fields._app_language == \"fr_fr\" || @fields._app_language == \"kr_ko\" || @fields._app_language == \"tr_tr\"",
+            "fullExpression": "@fields._app_language == \"us_en\" || @fields._app_language == \"es_es\" || @fields._app_language == \"cn_zh\" || @fields._app_language == \"fr_fr\" || @fields._app_language == \"tr_tr\"",
             "matchedExpression": "@fields._app_language",
             "type": "fields",
             "fieldName": "_app_language"
@@ -152,7 +146,6 @@
       },
       "_dynamicDependencies": {
         "@fields._app_language": [
-          "value",
           "value",
           "value",
           "value",
@@ -163,7 +156,7 @@
     },
     {
       "name": "okay_playdates_language",
-      "value": "@fields._app_language == \"us_en\" || @fields._app_language == \"es_es\" || @fields._app_language == \"cn_zh\" || @fields._app_language == \"fr_fr\" || @fields._app_language == \"kr_ko\" || @fields._app_language == \"tr_tr\"",
+      "value": "@fields._app_language == \"us_en\" || @fields._app_language == \"es_es\" || @fields._app_language == \"cn_zh\" || @fields._app_language == \"fr_fr\" || @fields._app_language == \"tr_tr\"",
       "_translations": {
         "value": {}
       },
@@ -173,37 +166,31 @@
       "_dynamicFields": {
         "value": [
           {
-            "fullExpression": "@fields._app_language == \"us_en\" || @fields._app_language == \"es_es\" || @fields._app_language == \"cn_zh\" || @fields._app_language == \"fr_fr\" || @fields._app_language == \"kr_ko\" || @fields._app_language == \"tr_tr\"",
+            "fullExpression": "@fields._app_language == \"us_en\" || @fields._app_language == \"es_es\" || @fields._app_language == \"cn_zh\" || @fields._app_language == \"fr_fr\" || @fields._app_language == \"tr_tr\"",
             "matchedExpression": "@fields._app_language",
             "type": "fields",
             "fieldName": "_app_language"
           },
           {
-            "fullExpression": "@fields._app_language == \"us_en\" || @fields._app_language == \"es_es\" || @fields._app_language == \"cn_zh\" || @fields._app_language == \"fr_fr\" || @fields._app_language == \"kr_ko\" || @fields._app_language == \"tr_tr\"",
+            "fullExpression": "@fields._app_language == \"us_en\" || @fields._app_language == \"es_es\" || @fields._app_language == \"cn_zh\" || @fields._app_language == \"fr_fr\" || @fields._app_language == \"tr_tr\"",
             "matchedExpression": "@fields._app_language",
             "type": "fields",
             "fieldName": "_app_language"
           },
           {
-            "fullExpression": "@fields._app_language == \"us_en\" || @fields._app_language == \"es_es\" || @fields._app_language == \"cn_zh\" || @fields._app_language == \"fr_fr\" || @fields._app_language == \"kr_ko\" || @fields._app_language == \"tr_tr\"",
+            "fullExpression": "@fields._app_language == \"us_en\" || @fields._app_language == \"es_es\" || @fields._app_language == \"cn_zh\" || @fields._app_language == \"fr_fr\" || @fields._app_language == \"tr_tr\"",
             "matchedExpression": "@fields._app_language",
             "type": "fields",
             "fieldName": "_app_language"
           },
           {
-            "fullExpression": "@fields._app_language == \"us_en\" || @fields._app_language == \"es_es\" || @fields._app_language == \"cn_zh\" || @fields._app_language == \"fr_fr\" || @fields._app_language == \"kr_ko\" || @fields._app_language == \"tr_tr\"",
+            "fullExpression": "@fields._app_language == \"us_en\" || @fields._app_language == \"es_es\" || @fields._app_language == \"cn_zh\" || @fields._app_language == \"fr_fr\" || @fields._app_language == \"tr_tr\"",
             "matchedExpression": "@fields._app_language",
             "type": "fields",
             "fieldName": "_app_language"
           },
           {
-            "fullExpression": "@fields._app_language == \"us_en\" || @fields._app_language == \"es_es\" || @fields._app_language == \"cn_zh\" || @fields._app_language == \"fr_fr\" || @fields._app_language == \"kr_ko\" || @fields._app_language == \"tr_tr\"",
-            "matchedExpression": "@fields._app_language",
-            "type": "fields",
-            "fieldName": "_app_language"
-          },
-          {
-            "fullExpression": "@fields._app_language == \"us_en\" || @fields._app_language == \"es_es\" || @fields._app_language == \"cn_zh\" || @fields._app_language == \"fr_fr\" || @fields._app_language == \"kr_ko\" || @fields._app_language == \"tr_tr\"",
+            "fullExpression": "@fields._app_language == \"us_en\" || @fields._app_language == \"es_es\" || @fields._app_language == \"cn_zh\" || @fields._app_language == \"fr_fr\" || @fields._app_language == \"tr_tr\"",
             "matchedExpression": "@fields._app_language",
             "type": "fields",
             "fieldName": "_app_language"
@@ -212,7 +199,6 @@
       },
       "_dynamicDependencies": {
         "@fields._app_language": [
-          "value",
           "value",
           "value",
           "value",

--- a/config.ts
+++ b/config.ts
@@ -8,7 +8,7 @@ config.google_drive = {
 
 config.git = {
   content_repo: "https://github.com/IDEMSInternational/efm-app-content.git",
-  content_tag_latest: "1.2.49",
+  content_tag_latest: "1.2.50",
 };
 
 config.android = {


### PR DESCRIPTION
Removed Korean from the learning steps and playdates displays. Also put back in the sorting code for sorting storybooks for all languages.